### PR TITLE
Camera Tracking

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,7 +19,6 @@ For a full list of contributors, view the [AUTHORS](AUTHORS) file
 - Make the orbit trails configurable
 - Add textures?
 - Make the bodies spin? (would need textures)
-- Make the camera auto-track an object
 - Make the lighting dim the further you are from an object
 - I'm not entirely sure the COG frame is 100% correct. I'll need to re-review it at a later date
 
@@ -90,19 +89,20 @@ If everything works without any errors, there should now be a `sim.exe` file in 
 | -t   | Set the time delta between steps              | Floats > 0.0            |
 | -d   | Enable debug printing to console              | N/A                     |
 | -h   | Open the help menu                            | N/A                     |
-| -n   | Define the number of bodies to render         | 0 - N (N < 64)                  |
+| -n   | Define the number of bodies to render         | 0 - N (N < 64)          |
 | -3   | Render the scene in 3d                        | N/A                     |
+| -f   | Set the scene config file                     | string (optional)       |
 
 
 ### Inititalization YAML
 
-The initial values for each body is defined in a YAML file, which must be named `init.yaml` and placed in the directory you are running the simulator from. Refer to the `init.example.yaml` for a starting place. 
+The initial values for each body is defined in a YAML file, which must be included with the `-f` flag. Refer to the `init.example.yaml` for a starting place. 
 
 The different keys that exist are:
 
 - Name: The name of the body. This is only used to differentiate them in parsing at this time.
 - Mass: The mass of the body in KG. Scientific notation is allowed. (Ex. 10E3, 1.65E5)
-- Radius: The radius of the body in KGs. Scientific notation is allowed. (Ex. 10E3, 1.65E5)
+- Radius: The radius of the body in meters. Scientific notation is allowed. (Ex. 10E3, 1.65E5)
 - Position: Two (or three) values seperated by a comma to represent the position vector of the body in meters. Scientific notation is allowed. (Ex. 10E3, 1.65E5)
 - Velocity: Two (or three) values seperated by a comma to represent the velocity vector of the body in meters. Scientific notation is allowed. (Ex. 10E3, 1.65E5)
 - Color: Hex color to define the color of the body
@@ -115,9 +115,11 @@ The different keys that exist are:
 
 ### Moving the camera in 3d
 
-In 3D, we can move the camera using WASD, and Space/LeftControl to move along the Y-axis.
-You can rotate the scene with I/K, and J/L
+In 3D, we can move the camera using `W`, `A`, `S`, `D`, and `SPACE`/`LEFT_CONTROL` to move along the Y-axis.
+You can rotate the scene with `I`/`K`, and `J`/`L`
 You can adjust the speed to be 1x, 2x, or 5x by pressing 1,2, or 5 respectively.
+You can also track bodies by pressing `T` and can cycle forwards and backwards through which body you'd like to track with `[` and `]` respectively.
+While tracking bodies, the camera moves around the tracked body using a spherical reference vector. You may move closer or further with `W`/`S` and orbit around the body using `A`/`D` horizontally, and `I`/`K` vertically.
 
 ### Known Issues
 - Compiling with an optimization setting higher than -O0 can cause crashes on Nvidia GPUs

--- a/include/graphics/render3d.h
+++ b/include/graphics/render3d.h
@@ -22,6 +22,10 @@ typedef struct camera{
     vector3 up;
     vector3 front;
     vector3 right;
+    bool tracking;
+    int tracked_body;
+    int num_bodies;
+    vector3 tracking_vector;
 } camera;
 
 typedef struct grid{

--- a/include/graphics/render3d.h
+++ b/include/graphics/render3d.h
@@ -25,7 +25,7 @@ typedef struct camera{
     bool tracking;
     int tracked_body;
     int num_bodies;
-    vector3 tracking_vector;
+    svector3 tracking_vector;
 } camera;
 
 typedef struct grid{

--- a/include/math/vector/vector3.h
+++ b/include/math/vector/vector3.h
@@ -21,6 +21,14 @@ typedef struct
 
 } dvector3;
 
+//3 Dimensional Spherical Vector
+typedef struct
+{
+    float r;
+    float az;
+    float el;
+} svector3;
+
 // normalize a two_d_vectpr to something that opengl can render
 vector3 normalize_vec3(vector3 vec, double min, double max);
 vector3 denormalize_vec3(vector3 vec, double min, double max);
@@ -52,5 +60,9 @@ dvector3 vector3_to_dvector3(vector3 vec);
 dvector3 subtract_dvec3s(dvector3 vec1, dvector3 vec2);
 
 dvector3 scale_dvec3(dvector3 vec, double s);
+
+svector3 cartesian_to_spherical(vector3);
+
+vector3 spherical_to_cartesian(svector3);
 
 #endif

--- a/include/utils/constants.h
+++ b/include/utils/constants.h
@@ -11,6 +11,8 @@ extern const long AU;
 #define RUN_LIMIT -1
 
 #define PI 3.14159265358979323846f
+#define DEG_TO_RAD (PI / 180.0f)
+#define RAD_TO_DEF (180.0f / PI)
 
 // speed of light in m/s
 extern const long c;

--- a/include/utils/constants.h
+++ b/include/utils/constants.h
@@ -12,7 +12,7 @@ extern const long AU;
 
 #define PI 3.14159265358979323846f
 #define DEG_TO_RAD (PI / 180.0f)
-#define RAD_TO_DEF (180.0f / PI)
+#define RAD_TO_DEG (180.0f / PI)
 
 // speed of light in m/s
 extern const long c;

--- a/src/graphics/controls.c
+++ b/src/graphics/controls.c
@@ -1,5 +1,6 @@
 #include "graphics/controls.h"
 #include "graphics/render3d.h"
+#include "utils/constants.h"
 
 // TODO add helper to make a new input button
 
@@ -15,37 +16,76 @@ void get_input(GLFWwindow* window, camera* cam){
 
     // move camera forward / back
     if (glfwGetKey(window, GLFW_KEY_W) == GLFW_PRESS){
-        cam->pos = add_vec3s(cam->pos, scale_vec3(cam->front, cam->speed));
+        if (!cam->tracking) {
+            cam->pos = add_vec3s(cam->pos, scale_vec3(cam->front, cam->speed));
+        } else {
+            if (cam->tracking_vector.r < 0.01f) {
+                cam->tracking_vector.r = 0.01f;
+            } else {
+                cam->tracking_vector.r -= cam->speed;
+            }
+        }
     }
     if (glfwGetKey(window, GLFW_KEY_S) == GLFW_PRESS){
-        cam->pos = add_vec3s(cam->pos, scale_vec3(cam->front, (-1) * cam->speed));
+        if (!cam->tracking) {
+            cam->pos = add_vec3s(cam->pos, scale_vec3(cam->front, (-1) * cam->speed));
+        } else {
+            cam->tracking_vector.r += cam->speed;
+        }
     }
     // move camera left / right
     if (glfwGetKey(window, GLFW_KEY_A) == GLFW_PRESS){
         // Splitting this into two lines to make it a bit cleaner
-        vector3 temp = vec3_unit_vector(cross_product(cam->front, cam->up)); 
-        cam->pos = add_vec3s(cam->pos, scale_vec3(temp, (-1) * cam->speed));
+        if (!cam->tracking) {
+            vector3 temp = vec3_unit_vector(cross_product(cam->front, cam->up)); 
+            cam->pos = add_vec3s(cam->pos, scale_vec3(temp, (-1) * cam->speed));
+        } else {
+            cam->tracking_vector.az -= cam->rotSpeed * DEG_TO_RAD;
+        }
     }
     if (glfwGetKey(window, GLFW_KEY_D) == GLFW_PRESS){
-        vector3 temp = vec3_unit_vector(cross_product(cam->front, cam->up)); 
-        cam->pos = add_vec3s(cam->pos, scale_vec3(temp, cam->speed));    
+        if (!cam->tracking) {
+            vector3 temp = vec3_unit_vector(cross_product(cam->front, cam->up)); 
+            cam->pos = add_vec3s(cam->pos, scale_vec3(temp, cam->speed));    
+        } else {
+            cam->tracking_vector.az += cam->rotSpeed * DEG_TO_RAD;
+        }
     }
     // move cam up
     if (glfwGetKey(window, GLFW_KEY_LEFT_CONTROL) == GLFW_PRESS){
-        cam->pos = add_vec3s(cam->pos, scale_vec3(cam->up, (-1) * cam->speed));
+        if (!cam->tracking) {
+            cam->pos = add_vec3s(cam->pos, scale_vec3(cam->up, (-1) * cam->speed));
+        }
     }
     // move cam down
     if (glfwGetKey(window, GLFW_KEY_SPACE) == GLFW_PRESS){
-        cam->pos = add_vec3s(cam->pos, scale_vec3(cam->up, cam->speed));
+        if (!cam->tracking) {
+            cam->pos = add_vec3s(cam->pos, scale_vec3(cam->up, cam->speed));
+        }
     }
 
     // x rotation
     if (glfwGetKey(window, GLFW_KEY_I) == GLFW_PRESS){
-        cam->pitch -= cam->rotSpeed;
-        
+        if (!cam->tracking) {
+            cam->pitch -= cam->rotSpeed;
+        } else {
+            if (cam->tracking_vector.el < 0.01f) {
+                cam->tracking_vector.el = 0.01f;
+            } else {
+                cam->tracking_vector.el -= cam->rotSpeed * DEG_TO_RAD;
+            }
+        }
     }
     if (glfwGetKey(window, GLFW_KEY_K) == GLFW_PRESS){
-        cam->pitch += cam->rotSpeed; 
+        if (!cam->tracking) {
+            cam->pitch += cam->rotSpeed;
+        } else {
+            if (cam->tracking_vector.el > PI - 0.01f) {
+                cam->tracking_vector.el = PI - 0.01f;
+            } else {
+                cam->tracking_vector.el += cam->rotSpeed * DEG_TO_RAD;
+            }
+        }
     }
 
     // y rotation
@@ -67,10 +107,7 @@ void get_input(GLFWwindow* window, camera* cam){
     // track prev body
     static bool left_was_pressed = false;
     bool left_pressed = glfwGetKey(window, GLFW_KEY_LEFT_BRACKET) == GLFW_PRESS;
-    if (left_pressed && !left_was_pressed){
-        if (!cam->tracking) {
-          return;
-        }
+    if (left_pressed && !left_was_pressed && cam->tracking){
         cam->tracked_body = (cam->tracked_body - 1 + cam->num_bodies) % cam->num_bodies;
     }
     left_was_pressed = left_pressed;
@@ -78,10 +115,7 @@ void get_input(GLFWwindow* window, camera* cam){
     // track next body
     static bool right_was_pressed = false;
     bool right_pressed = glfwGetKey(window, GLFW_KEY_RIGHT_BRACKET) == GLFW_PRESS;
-    if (right_pressed && !right_was_pressed){
-        if (!cam->tracking) {
-          return;
-        }
+    if (right_pressed && !right_was_pressed && cam->tracking){
         cam->tracked_body = (cam->tracked_body + 1) % cam->num_bodies;
     }
     right_was_pressed = right_pressed;
@@ -125,7 +159,6 @@ void get_input(GLFWwindow* window, camera* cam){
     if (glfwGetKey(window, GLFW_KEY_R)){
         cam->pos = cameraPosDefault;
         // Also need to reset the rotation
-        cam->yaw = 0.0f;
         cam->yaw = -90.0f;
     }
 

--- a/src/graphics/controls.c
+++ b/src/graphics/controls.c
@@ -40,7 +40,7 @@ void get_input(GLFWwindow* window, camera* cam){
             vector3 temp = vec3_unit_vector(cross_product(cam->front, cam->up)); 
             cam->pos = add_vec3s(cam->pos, scale_vec3(temp, (-1) * cam->speed));
         } else {
-            cam->tracking_vector.az -= cam->rotSpeed * DEG_TO_RAD;
+            cam->tracking_vector.az += cam->rotSpeed * DEG_TO_RAD;
         }
     }
     if (glfwGetKey(window, GLFW_KEY_D) == GLFW_PRESS){
@@ -48,7 +48,7 @@ void get_input(GLFWwindow* window, camera* cam){
             vector3 temp = vec3_unit_vector(cross_product(cam->front, cam->up)); 
             cam->pos = add_vec3s(cam->pos, scale_vec3(temp, cam->speed));    
         } else {
-            cam->tracking_vector.az += cam->rotSpeed * DEG_TO_RAD;
+            cam->tracking_vector.az -= cam->rotSpeed * DEG_TO_RAD;
         }
     }
     // move cam up

--- a/src/graphics/controls.c
+++ b/src/graphics/controls.c
@@ -1,6 +1,8 @@
 #include "graphics/controls.h"
 #include "graphics/render3d.h"
 
+// TODO add helper to make a new input button
+
 // All the if statements for keypresses in GLFW
 // Updates the camera struct as needed
 void get_input(GLFWwindow* window, camera* cam){
@@ -53,6 +55,36 @@ void get_input(GLFWwindow* window, camera* cam){
     if (glfwGetKey(window, GLFW_KEY_L) == GLFW_PRESS){
         cam->yaw += cam->rotSpeed; 
     }
+
+    // track body
+    static bool t_was_pressed = false;
+    bool t_pressed = glfwGetKey(window, GLFW_KEY_T) == GLFW_PRESS;
+    if (t_pressed && !t_was_pressed){
+        cam->tracking = !cam->tracking;
+    }
+    t_was_pressed = t_pressed;
+
+    // track prev body
+    static bool left_was_pressed = false;
+    bool left_pressed = glfwGetKey(window, GLFW_KEY_LEFT_BRACKET) == GLFW_PRESS;
+    if (left_pressed && !left_was_pressed){
+        if (!cam->tracking) {
+          return;
+        }
+        cam->tracked_body = (cam->tracked_body - 1 + cam->num_bodies) % cam->num_bodies;
+    }
+    left_was_pressed = left_pressed;
+
+    // track next body
+    static bool right_was_pressed = false;
+    bool right_pressed = glfwGetKey(window, GLFW_KEY_RIGHT_BRACKET) == GLFW_PRESS;
+    if (right_pressed && !right_was_pressed){
+        if (!cam->tracking) {
+          return;
+        }
+        cam->tracked_body = (cam->tracked_body + 1) % cam->num_bodies;
+    }
+    right_was_pressed = right_pressed;
 
     // this adjusts the camera speed
     if (glfwGetKey(window, GLFW_KEY_1) == GLFW_PRESS){

--- a/src/graphics/render3d.c
+++ b/src/graphics/render3d.c
@@ -424,14 +424,14 @@ void render3d(body_3d* bodies_array[], Settings* config_settings){
     cam->pos = cameraPosDefault;
     cam->pitch = 0.0f;
     cam->yaw = -90.0f;
-    cam->speedMultiplier = 1.0f;
+    cam->speedMultiplier = 3.0f;
     
     vector3 up = {0.0f, 1.0f, 0.0f};
 
     cam->tracking = false;
     cam->tracked_body = 0;
     cam->num_bodies = num_bodies;
-    cam->tracking_vector = (vector3){0.0f, 0.0f, 0.0f};
+    cam->tracking_vector = (svector3){0.0f, 0.0f, 0.0f};
 
     // Init the bodies
     init_3d_bodies(bodies_array, num_bodies);
@@ -549,6 +549,13 @@ void render3d(body_3d* bodies_array[], Settings* config_settings){
         lastFrame = currentTime;  
         if ( currentTime - lastTime >= 1.0 && debug){ // If last prinf() was more than 1 sec ago
             show_debug_message(run, nbFrames, bodies_array, num_bodies);
+            if (cam->tracking) {
+                vector3 body_pos = normalize_vec3(bodies_array[cam->tracked_body]->pos, SPACE_MIN, SPACE_MAX);
+                printf("cam pos: (%.3f, %.3f, %.3f) | body pos: (%.3f, %.3f, %.3f) | offset: (%.3f, %.3f, %.3f)\n",
+                    cam->pos.x, cam->pos.y, cam->pos.z,
+                    body_pos.x, body_pos.y, body_pos.z,
+                    cam->tracking_vector.r, cam->tracking_vector.az, cam->tracking_vector.el);
+            }
             lastTime += 1.0;
             nbFrames = 0;
         }
@@ -567,30 +574,21 @@ void render3d(body_3d* bodies_array[], Settings* config_settings){
         vector3 cameraFront = vec3_unit_vector(direction);
 
         cam->speed = 0.3f * deltaTime * cam->speedMultiplier; 
-        cam->rotSpeed = 2.5f * deltaTime * cam->speedMultiplier;
+        cam->rotSpeed = 3.0f * deltaTime * cam->speedMultiplier;
         cam->front = cameraFront;
 
-        vector3 prev_camera_pos = cam->pos; // used to compute changing relative vector
-        
         get_input(window, cam);
-        
-        // if tracking, and user is moving the camera, compute the relative tracking vector to the body
-        // if you turn this off (comment out this code), you can have stationary camera tracking. do we want this as a toggle option?
-        if (cam->tracking && ((prev_camera_pos.x != cam->pos.x) ||
-            (prev_camera_pos.y != cam->pos.y) ||
-            (prev_camera_pos.z != cam->pos.z))) 
-            cam->tracking_vector = subtract_vec3s(cam->pos, normalize_vec3(bodies_array[cam->tracked_body]->pos, SPACE_MIN, SPACE_MAX));
- 
+
         // new tracking, capture tracking vector from body to camera in space
         // OR
         // cycled to a different body, recapture the tracking vector
         if ((!was_tracking && cam->tracking) || (was_tracking && cam->tracking && cam->tracked_body != prev_tracked)){
             vector3 normed_track = normalize_vec3(bodies_array[cam->tracked_body]->pos, SPACE_MIN, SPACE_MAX);
-            cam->tracking_vector = subtract_vec3s(cam->pos, normed_track);
+            cam->tracking_vector = cartesian_to_spherical(subtract_vec3s(cam->pos, normed_track));
         }
         // disabled tracking, rsync yaw/pitch from actual look direction
         if (was_tracking && !cam->tracking) {
-            vector3 look = vec3_unit_vector(scale_vec3(cam->tracking_vector, -1.0));
+            vector3 look = vec3_unit_vector(scale_vec3(spherical_to_cartesian(cam->tracking_vector), -1.0));
             cam->pitch = asinf(look.y) * RAD_TO_DEG;
             cam->yaw = atan2f(look.z, look.x) * RAD_TO_DEG;
             cameraFront = look;
@@ -598,17 +596,18 @@ void render3d(body_3d* bodies_array[], Settings* config_settings){
         // while tracking is on
         if (cam->tracking) {
             body_3d *target = bodies_array[cam->tracked_body];
-            cam->pos = add_vec3s(normalize_vec3(target->pos, SPACE_MIN, SPACE_MAX), cam->tracking_vector);
-            cameraFront = vec3_unit_vector(subtract_vec3s(normalize_vec3(target->pos, SPACE_MIN, SPACE_MAX), cam->pos));
+            vector3 normalized_target = normalize_vec3(target->pos, SPACE_MIN, SPACE_MAX);
+            cam->pos = add_vec3s(normalized_target, spherical_to_cartesian(cam->tracking_vector));
+            cameraFront = vec3_unit_vector(subtract_vec3s(normalized_target, cam->pos));
         }
-          
+
 
         // These are the steps to calculte the vectors needed for a lookAt matrix
         vector3 cameraTarget = add_vec3s(cameraFront, cam->pos);
         vector3 cameraDirection = vec3_unit_vector(subtract_vec3s(cam->pos, cameraTarget));
         vector3 cameraRight = vec3_unit_vector(cross_product(up, cameraDirection));
         vector3 cameraUp = cross_product(cameraDirection, cameraRight);
-    
+
         // View  Rotation Matrix Matrix
         matrix4 view = {
             {cameraRight.x, cameraUp.x, cameraDirection.x, 0},

--- a/src/graphics/render3d.c
+++ b/src/graphics/render3d.c
@@ -401,7 +401,7 @@ void render3d(body_3d* bodies_array[], Settings* config_settings){
     glClearColor(0.0f, 0.0f, 0.0f, 1.0f);
 
     //define the projection matrix
-    float fov = 60.0f * 3.14159f / 180.0f;
+    float fov = 60.0f * DEG_TO_RAD;
     float aspect = 1600.0f / 900.0f;
     float near = 0.001f;
     float far = 1000.0f;
@@ -427,6 +427,11 @@ void render3d(body_3d* bodies_array[], Settings* config_settings){
     cam->speedMultiplier = 1.0f;
     
     vector3 up = {0.0f, 1.0f, 0.0f};
+
+    cam->tracking = false;
+    cam->tracked_body = 0;
+    cam->num_bodies = num_bodies;
+    cam->tracking_vector = (vector3){0.0f, 0.0f, 0.0f};
 
     // Init the bodies
     init_3d_bodies(bodies_array, num_bodies);
@@ -535,7 +540,6 @@ void render3d(body_3d* bodies_array[], Settings* config_settings){
     vector3 lightLocations[numLightSources]; 
 
     glUniform1i(numLightSourcesLoc, numLightSources);
-
     while ( !glfwWindowShouldClose( window ) ) {
         nbFrames++;
         run++;
@@ -549,8 +553,11 @@ void render3d(body_3d* bodies_array[], Settings* config_settings){
             nbFrames = 0;
         }
 
-        float yaw = cam->yaw * 3.14159f / 180.0f;
-        float pitch = cam->pitch * 3.14159f / 180.0f;
+        bool was_tracking = cam->tracking;
+        int prev_tracked = cam->tracked_body;
+
+        float yaw = cam->yaw * DEG_TO_RAD;
+        float pitch = cam->pitch * DEG_TO_RAD;
 
         // This is used to handle rotation of the camera
         vector3 direction;
@@ -559,20 +566,49 @@ void render3d(body_3d* bodies_array[], Settings* config_settings){
         direction.z = sin(yaw) * cos(pitch);
         vector3 cameraFront = vec3_unit_vector(direction);
 
+        cam->speed = 0.3f * deltaTime * cam->speedMultiplier; 
+        cam->rotSpeed = 2.5f * deltaTime * cam->speedMultiplier;
+        cam->front = cameraFront;
+
+        vector3 prev_camera_pos = cam->pos; // used to compute changing relative vector
+        
+        get_input(window, cam);
+        
+        // if tracking, and user is moving the camera, compute the relative tracking vector to the body
+        // if you turn this off (comment out this code), you can have stationary camera tracking. do we want this as a toggle option?
+        if (cam->tracking && ((prev_camera_pos.x != cam->pos.x) ||
+            (prev_camera_pos.y != cam->pos.y) ||
+            (prev_camera_pos.z != cam->pos.z))) 
+            cam->tracking_vector = subtract_vec3s(cam->pos, normalize_vec3(bodies_array[cam->tracked_body]->pos, SPACE_MIN, SPACE_MAX));
+ 
+        // new tracking, capture tracking vector from body to camera in space
+        // OR
+        // cycled to a different body, recapture the tracking vector
+        if ((!was_tracking && cam->tracking) || (was_tracking && cam->tracking && cam->tracked_body != prev_tracked)){
+            vector3 normed_track = normalize_vec3(bodies_array[cam->tracked_body]->pos, SPACE_MIN, SPACE_MAX);
+            cam->tracking_vector = subtract_vec3s(cam->pos, normed_track);
+        }
+        // disabled tracking, rsync yaw/pitch from actual look direction
+        if (was_tracking && !cam->tracking) {
+            vector3 look = vec3_unit_vector(scale_vec3(cam->tracking_vector, -1.0));
+            cam->pitch = asinf(look.y) * RAD_TO_DEG;
+            cam->yaw = atan2f(look.z, look.x) * RAD_TO_DEG;
+            cameraFront = look;
+        }
+        // while tracking is on
+        if (cam->tracking) {
+            body_3d *target = bodies_array[cam->tracked_body];
+            cam->pos = add_vec3s(normalize_vec3(target->pos, SPACE_MIN, SPACE_MAX), cam->tracking_vector);
+            cameraFront = vec3_unit_vector(subtract_vec3s(normalize_vec3(target->pos, SPACE_MIN, SPACE_MAX), cam->pos));
+        }
+          
+
         // These are the steps to calculte the vectors needed for a lookAt matrix
         vector3 cameraTarget = add_vec3s(cameraFront, cam->pos);
         vector3 cameraDirection = vec3_unit_vector(subtract_vec3s(cam->pos, cameraTarget));
         vector3 cameraRight = vec3_unit_vector(cross_product(up, cameraDirection));
         vector3 cameraUp = cross_product(cameraDirection, cameraRight);
-
-        cam->speed = 0.3f * deltaTime * cam->speedMultiplier; 
-        cam->rotSpeed = 2.5f * deltaTime * cam->speedMultiplier;
-        cam->front = cameraFront;
-        cam->right = cameraRight;
-        cam->up = cameraUp;
-
-        get_input(window, cam);
-
+    
         // View  Rotation Matrix Matrix
         matrix4 view = {
             {cameraRight.x, cameraUp.x, cameraDirection.x, 0},
@@ -583,6 +619,9 @@ void render3d(body_3d* bodies_array[], Settings* config_settings){
                 (-1) * dot_vec3s(cameraDirection, cam->pos)
                 ,1}
         };
+
+        cam->right = cameraRight;
+        cam->up = cameraUp;
 
         glfwPollEvents();
         glClear( GL_COLOR_BUFFER_BIT | GL_DEPTH_BUFFER_BIT );
@@ -608,7 +647,7 @@ void render3d(body_3d* bodies_array[], Settings* config_settings){
         }else{
             exit(1); // should never be reached
         }
-
+      
         for(int i=0;i<num_bodies;i++){ 
 
             

--- a/src/math/vector3.c
+++ b/src/math/vector3.c
@@ -101,3 +101,19 @@ dvector3 vector3_to_dvector3(vector3 vec){
     dvector3 scaled = {vec.x * s, vec.y * s, vec.z * s};
     return scaled;
 }
+
+[[gnu::pure]] svector3 cartesian_to_spherical(vector3 vec) {
+    svector3 result;
+    result.r = sqrtf((vec.x * vec.x) + (vec.y * vec.y) + (vec.z * vec.z));
+    result.az = atan2f(vec.y, vec.x);
+    result.el = acosf(vec.z / result.r);
+    return result;
+}
+
+[[gnu::pure]] vector3 spherical_to_cartesian(svector3 vec) {
+    vector3 result;
+    result.x = vec.r * sinf(vec.el) * cosf(vec.az);
+    result.y = vec.r * cosf(vec.el);
+    result.z = vec.r * sinf(vec.el) * sinf(vec.az);
+    return result;
+}

--- a/src/math/vector3.c
+++ b/src/math/vector3.c
@@ -105,8 +105,8 @@ dvector3 vector3_to_dvector3(vector3 vec){
 [[gnu::pure]] svector3 cartesian_to_spherical(vector3 vec) {
     svector3 result;
     result.r = sqrtf((vec.x * vec.x) + (vec.y * vec.y) + (vec.z * vec.z));
-    result.az = atan2f(vec.y, vec.x);
-    result.el = acosf(vec.z / result.r);
+    result.az = atan2f(vec.z, vec.x);
+    result.el = acosf(vec.y / result.r);
     return result;
 }
 


### PR DESCRIPTION
# The plan

## How to use it
Enable camera tracking by pressing `T`. The camera will then follow the "first" body (chosen by which is created first in `bodies_array`). Once tracking is enabled, you can cycle between bodies to track using the `[` and `]` keys. Pressing `T` again disables tracking and returns to a free camera.

## How it works
When you press `T` your current relative vector to the target body is captured. Each frame the camera position is updates to retain the same relative vector towards the body. The look direction is recomputed each frame as well, and will override the pitch/yaw values.

If you move the camera like normal, when tracking is enabled, you are updating the relative vector. The camera will move freely, but once you stop moving, a new current relative vector is captured. When you are moving during tracking, you are moving relative to the tracked body, rather than in normal space. _this bit will be tricky_